### PR TITLE
Base plugin on ghc-lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 on:
   pull_request:
   push:
-          #  branches: [master]
+    branches: [master]
 
 jobs:
   cabal:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
         cabal: ["3.2"]
         ghc:
           - "8.6.5"
-          - "8.10.1"
+          - "8.8.3"
+          - "8.10.2"
 
     steps:
     - uses: actions/checkout@v2
@@ -47,4 +48,3 @@ jobs:
     - name: Test
       run: |
         cabal test all
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,19 @@ on:
     branches: [master]
 
 jobs:
+  # TODO: Not sure how to cache this one.. cachix?
+  nix:
+    name: nix build
+    runs-on: ubuntu-latest
+    container:
+      image: 'nixos/nix:2.3.6'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          nix-build
+
   cabal:
     name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-
 
     - name: Build
       run: |

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -19,6 +19,7 @@ library
   -- other-extensions:
   build-depends:
       base >=4.12
+    , data-default
     , ghc-lib
     , syb
     , containers
@@ -26,6 +27,7 @@ library
     , mtl
     , pretty
     , pretty-show
+    , template-haskell
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall -Wcompat

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -19,16 +19,13 @@ library
   -- other-extensions:
   build-depends:
       base >=4.12
-    , ghc >=8.6
+    , ghc-lib
     , syb
     , containers
     , lens
     , mtl
     , pretty
-    , parsec
     , pretty-show
-    , template-haskell
-    , data-default
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -Wall
+  ghc-options:         -Wall -Wcompat

--- a/default.nix
+++ b/default.nix
@@ -13,4 +13,21 @@ let lib = nixpkgs.lib;
               [ "cabal.project.local" ".ghc.environment." ]
         ) src;
 
-in nixpkgs.haskellPackages.callCabal2nix "circuit-notation" (filterHaskellSource ./.) {}
+    haskellPackages =
+      nixpkgs.haskellPackages.extend (super: self:
+      {
+        ghc-lib = self.callHackageDirect {
+          pkg = "ghc-lib";
+          ver = "8.10.2.20200916";
+          sha256 = "1gx0ijay9chachmd1fbb61md3zlvj24kk63fk3dssx8r9c2yp493";
+        } {};
+
+        ghc-lib-parser = self.callHackageDirect {
+          pkg = "ghc-lib-parser";
+          ver = "8.10.2.20200916";
+          sha256 = "1apm9zn484sm6b8flbh6a2kqnv1wjan4l58b81cic5fc1jsqnyjk";
+        } {};
+
+      });
+
+in haskellPackages.callCabal2nix "circuit-notation" (filterHaskellSource ./.) {}


### PR DESCRIPTION
This means we can't use TH anymore, hence using unqualified, dynamically
bound names for 'def' and 'const'.