### PR TITLE
Externalize non-circuit-notation names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
     - uses: actions/setup-haskell@v1.1.1
       id: setup-haskell-cabal
       name: Setup Haskell
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -57,7 +59,8 @@ jobs:
     - name: Build
       run: |
         cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
-        cabal build all
+        cabal build all --write-ghc-environment-files=always
+        ghc -iexample Example
 
     - name: Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         cabal: ["3.2"]
         ghc:
           - "8.6.5"
-          - "8.10.1"
+          # - "8.10.1"
 
     steps:
     - uses: actions/checkout@v2

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -22,8 +22,7 @@ library
     , clash-prelude >= 1.0
     , containers
     , data-default
-    -- GHC 8.8 explicitly not supported
-    , ghc (>=8.6 && <8.8) || (>=8.10 && < 9.0)
+    , ghc >=8.6 && <8.8
     , syb
     , lens
     , mtl

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -14,7 +14,7 @@ extra-source-files:  CHANGELOG.md, README.md
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     CircuitNotation
+  exposed-modules:     CircuitNotation Circuit
   -- other-modules:
   -- other-extensions:
   build-depends:
@@ -22,7 +22,8 @@ library
     , clash-prelude >= 1.0
     , containers
     , data-default
-    , ghc >=8.6
+    -- GHC 8.8 explicitly not supported
+    , ghc (>=8.6 && <8.8) || (>=8.10 && < 9.0)
     , syb
     , lens
     , mtl

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -19,16 +19,17 @@ library
   -- other-extensions:
   build-depends:
       base >=4.12
+    , clash-prelude >= 1.0
+    , containers
+    , data-default
     , ghc >=8.6
     , syb
-    , containers
     , lens
     , mtl
     , pretty
     , parsec
     , pretty-show
     , template-haskell
-    , data-default
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -32,6 +32,8 @@ module Example where
 
 import Circuit
 
+import Clash.Prelude (Signal, Vec(..))
+
 idCircuit :: Circuit a a
 idCircuit = idC
 
@@ -52,7 +54,7 @@ noLambda = circuit $ do
   i <- circuitA
   idC -< i
 
--- noLambda = 
+-- noLambda =
 --   let
 --     inferenceHelper ::
 --       () =>

--- a/src/Circuit.hs
+++ b/src/Circuit.hs
@@ -22,22 +22,8 @@ This file contains the 'Circuit' type, that the notation describes.
 
 module Circuit where
 
+import Clash.Prelude (Domain, Signal, Vec(..))
 import Data.Default
-import GHC.TypeLits
-import Unsafe.Coerce
-
-data Domain
-
--- | Infinite sequence of values.
-data Signal (dom :: Domain) a = a :- Signal dom a
-  deriving Functor
-
-instance Default a => Default (Signal dom a) where
-  def = pure def
-
-instance Applicative (Signal dom) where
-  pure a = a :- pure a
-  (f :- fs) <*> (a :- as) = f a :- (fs <*> as)
 
 type family Fwd a
 type family Bwd a
@@ -62,26 +48,6 @@ instance Default DFS2M where
 
 type instance Fwd (DF dom a) = Signal dom (DFM2S a)
 type instance Bwd (DF dom a) = Signal dom DFS2M
-
-data Vec n a where
-  Nil :: Vec 0 a
-  Cons :: a -> Vec n a -> Vec (n + 1) a
-
-headV :: Vec (n + 1) a -> a
-headV (x `Cons` _) = x
-headV Nil = error ""
-tailV :: forall n a. Vec (n + 1) a -> Vec n a
-tailV (_ `Cons` xs) = unsafeCoerce xs
-tailV Nil = error ""
-
-pattern (:>) :: a -> Vec n a -> Vec (n + 1) a
-pattern (:>) x xs <- ((\ys -> (headV ys, tailV ys)) -> (x,xs))
-  where
-      (:>) x xs = Cons x xs
-infixr 5 :>
-
-myVec :: Vec 2 Int
-myVec = 1 :> 2 :> Nil
 
 type instance Fwd (Vec n a) = Vec n (Fwd a)
 type instance Bwd (Vec n a) = Vec n (Bwd a)

--- a/src/CircuitNotation.hs
+++ b/src/CircuitNotation.hs
@@ -509,6 +509,8 @@ bindMaster (L loc expr) = case expr of
     | rdrName == thName '() -> Tuple []
     | rdrName == thName '[] -> Vec vloc []
     | otherwise -> Ref (PortName vloc (fromRdrName rdrName))
+  HsApp _xapp (L _ (HsVar _ (L _ (GHC.Unqual occ)))) sig
+    | OccName.occNameString occ == "Signal" -> SignalExpr sig
   ExplicitTuple _ tups _ -> let
     vals = fmap (\(L _ (Present _ e)) -> e) tups
     in Tuple $ fmap bindMaster vals
@@ -873,7 +875,7 @@ transform debug = SYB.everywhereM (SYB.mkM transform') where
   -- the circuit keyword directly applied (either with parenthesis or with BlockArguments)
   transform' (L _ (HsApp _xapp (L _ circuitVar) lappB))
     | isCircuitVar circuitVar = runCircuitM $ do
-        x <- parseCircuit lappB >> completeUnderscores >> circuitQQExpM 
+        x <- parseCircuit lappB >> completeUnderscores >> circuitQQExpM
         when debug $ ppr x
         pure x
 


### PR DESCRIPTION
Eliminates the need to import definitions `:>`, `Nil`, .. when using the plugin. API remains is backwards compatible. 

Draft PR todo:

- [x] Add examples in `example/` as tests

@cchalmers Any comments?