### PR TITLE
Drop Arrows dependency for GHC 8.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         cabal: ["3.2"]
         ghc:
           - "8.6.5"
-          # - "8.10.1"
+          - "8.10.1"
 
     steps:
     - uses: actions/checkout@v2

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -22,7 +22,7 @@ library
     , clash-prelude >= 1.0
     , containers
     , data-default
-    , ghc >=8.6 && <8.8
+    , ghc (>=8.6 && <8.8) || (>=8.10 && < 9.0)
     , syb
     , lens
     , mtl

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -10,12 +10,16 @@
 This file contains examples of using the Circuit Notation.
 -}
 
-{-# LANGUAGE Arrows              #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE DataKinds        #-}
+
+#if __GLASGOW_HASKELL__ < 810
+{-# LANGUAGE Arrows #-}
+#endif
 
 {-# OPTIONS -fplugin=CircuitNotation #-}
 {-# OPTIONS -fplugin-opt=CircuitNotation:debug #-}
@@ -37,8 +41,16 @@ import Clash.Prelude (Signal, Vec(..))
 idCircuit :: Circuit a a
 idCircuit = idC
 
-swapC :: Circuit (a,b) (b,a)
-swapC = id $ circuit $ \ ~(a,b) -> ~(b,a)
+#if __GLASGOW_HASKELL__ < 810
+swapC0 :: Circuit (a,b) (b,a)
+swapC0 = id $ circuit $ \ ~(a,b) -> ~(b,a)
+#endif
+
+swapC1 :: Circuit (a,b) (b,a)
+swapC1 = id $ circuit $ \ ~(a,b) -> (b,a)
+
+swapC2 :: Circuit (a,b) (b,a)
+swapC2 = id $ circuit $ \ (a,b) -> (b,a)
 
 circuitA :: Circuit () (DF domain Int)
 circuitA = Circuit (\_ -> () :-> pure (DFM2S True 3))


### PR DESCRIPTION
Arrow notation is now picked up as if `-<` was a "normal" operator