### PR TITLE
allow multi-master with trivial Bwd direction e.g. Signal

### DIFF
--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -38,4 +38,4 @@ Test-Suite library-testsuite
   type:             exitcode-stdio-1.0
   main-is:          unittests.hs
   hs-source-dirs:   tests
-  build-depends:    base, circuit-notation
+  build-depends:    base, circuit-notation, clash-prelude >= 1.0

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -37,5 +37,6 @@ Test-Suite library-testsuite
   default-language: Haskell2010
   type:             exitcode-stdio-1.0
   main-is:          unittests.hs
-  hs-source-dirs:   tests
-  build-depends:    base, circuit-notation
+  other-modules:    Example
+  hs-source-dirs:   tests, example
+  build-depends:    base, circuit-notation, clash-prelude >= 1.0

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -38,4 +38,4 @@ Test-Suite library-testsuite
   type:             exitcode-stdio-1.0
   main-is:          unittests.hs
   hs-source-dirs:   tests
-  build-depends:    base, circuit-notation, clash-prelude >= 1.0
+  build-depends:    base, circuit-notation

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -10,15 +10,15 @@
 This file contains examples of using the Circuit Notation.
 -}
 
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE DataKinds        #-}
 
 #if __GLASGOW_HASKELL__ < 810
-{-# LANGUAGE Arrows #-}
+{-# LANGUAGE Arrows              #-}
 #endif
 
 {-# OPTIONS -fplugin=CircuitNotation #-}
@@ -34,9 +34,9 @@ This file contains examples of using the Circuit Notation.
 
 module Example where
 
-import Circuit
+import           Circuit
 
-import Clash.Prelude (Signal, Vec(..))
+import           Clash.Prelude (Signal, Vec (..))
 
 idCircuit :: Circuit a a
 idCircuit = idC
@@ -139,6 +139,14 @@ vec0 = circuit \[] -> ()
 vec00 :: Circuit (Vec 0 a) (Vec 0 a)
 vec00 = circuit \[] -> []
 
+-- test that signals can be duplicated
+dupSignalC0 :: Circuit (Signal dom Bool) (Signal dom Bool, Signal dom Bool)
+dupSignalC0 = circuit $ \x -> (x, x)
+
+dupSignalC1 :: Circuit (Signal dom Bool) (Signal dom Bool, Signal dom Bool, Signal dom Bool)
+dupSignalC1 = circuit $ \x -> do
+    y <- idC -< x
+    idC -< (y, y, x)
 
 -- -- myDesire :: Circuit Int Char
 -- -- myDesire = Circuit (\(aM2S,bS2M) -> let

--- a/shell.nix
+++ b/shell.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation {
 
   buildInputs = [
     ghc
-    cabal-install
-    haskellPackages.ghcid
+    # cabal-install
+    # haskellPackages.ghcid
     haskellPackages.stylish-haskell
   ];
 

--- a/src/Circuit.hs
+++ b/src/Circuit.hs
@@ -76,6 +76,9 @@ class TrivialBwd a where
 instance TrivialBwd () where
   unitBwd = ()
 
+instance (TrivialBwd a) => TrivialBwd (Signal dom a) where
+  unitBwd = pure unitBwd
+
 instance (TrivialBwd a, KnownNat n) => TrivialBwd (Vec n a) where
   unitBwd = repeat unitBwd
 

--- a/src/Circuit.hs
+++ b/src/Circuit.hs
@@ -11,19 +11,18 @@ This file contains the 'Circuit' type, that the notation describes.
 -}
 
 {-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE PatternSynonyms     #-}
-{-# LANGUAGE ViewPatterns        #-}
 
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE GADTs        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module Circuit where
 
-import Clash.Prelude (Domain, Signal, Vec(..))
-import Data.Default
+import           Clash.Prelude
 
 type family Fwd a
 type family Bwd a
@@ -70,3 +69,27 @@ type instance Bwd (Signal dom a) = ()
 -- | Circuit type.
 newtype Circuit a b = Circuit { runCircuit :: CircuitT a b }
 type CircuitT a b = (Fwd a :-> Bwd b) -> (Bwd a :-> Fwd b)
+
+class TrivialBwd a where
+  unitBwd :: a
+
+instance TrivialBwd () where
+  unitBwd = ()
+
+instance (TrivialBwd a, KnownNat n) => TrivialBwd (Vec n a) where
+  unitBwd = repeat unitBwd
+
+instance (TrivialBwd a, TrivialBwd b) => TrivialBwd (a,b) where
+  unitBwd = (unitBwd, unitBwd)
+
+instance (TrivialBwd a, TrivialBwd b, TrivialBwd c) => TrivialBwd (a,b,c) where
+  unitBwd = (unitBwd, unitBwd, unitBwd)
+
+instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d) => TrivialBwd (a,b,c,d) where
+  unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd)
+
+instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e) => TrivialBwd (a,b,c,d,e) where
+  unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd, unitBwd)
+
+instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e, TrivialBwd f) => TrivialBwd (a,b,c,d,e,f) where
+  unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd)

--- a/src/CircuitNotation.hs
+++ b/src/CircuitNotation.hs
@@ -657,7 +657,7 @@ checkCircuit = do
         when (length ss > 1) $
           errM (head ss) $ "Slave port " <> show name <> " defined " <> show (length ss) <> " times"
 
-        -- if master is defined multiple times, we try to broadcast it
+        -- if master is defined multiple times, we broadcast it
         if length ms > 1
           then pure [name]
           else pure []

--- a/tests/unittests.hs
+++ b/tests/unittests.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE Arrows #-}
-
 -- This option is a test by itself: if we were to export a plugin with the
 -- wrong type or name, GHC would refuse to compile this file.
 {-# OPTIONS -fplugin=CircuitNotation #-}
@@ -7,19 +5,6 @@
 module Main where
 
 import           Circuit
-import           Clash.Prelude
 
 main :: IO ()
 main = pure ()
-
-testIdCircuit :: Circuit (Signal dom Bool) (Signal dom Bool)
-testIdCircuit = circuit $ \x -> x
-
--- test that signals can be duplicated
-testDupCircuit :: Circuit (Signal dom Bool) (Signal dom Bool, Signal dom Bool)
-testDupCircuit = circuit $ \x -> (x, x)
-
-testDup2Circuit :: Circuit (Signal dom Bool) (Signal dom Bool, Signal dom Bool, Signal dom Bool)
-testDup2Circuit = circuit $ \x -> do
-    y <- idC -< x
-    idC -< (y, y, x)

--- a/tests/unittests.hs
+++ b/tests/unittests.hs
@@ -6,5 +6,20 @@
 
 module Main where
 
+import           Circuit
+import           Clash.Prelude
+
 main :: IO ()
 main = pure ()
+
+testIdCircuit :: Circuit (Signal dom Bool) (Signal dom Bool)
+testIdCircuit = circuit $ \x -> x
+
+-- test that signals can be duplicated
+testDupCircuit :: Circuit (Signal dom Bool) (Signal dom Bool, Signal dom Bool)
+testDupCircuit = circuit $ \x -> (x, x)
+
+testDup2Circuit :: Circuit (Signal dom Bool) (Signal dom Bool, Signal dom Bool, Signal dom Bool)
+testDup2Circuit = circuit $ \x -> do
+    y <- idC -< x
+    idC -< (y, y, x)

--- a/tests/unittests.hs
+++ b/tests/unittests.hs
@@ -5,6 +5,7 @@
 module Main where
 
 import           Circuit
+import           Example
 
 main :: IO ()
 main = pure ()


### PR DESCRIPTION
This allows you to write circuits like:
```haskell
testDupCircuit :: Circuit (Signal dom Bool) (Signal dom Bool, Signal dom Bool)
testDupCircuit = circuit $ \x -> (x, x)
```

When the `Bwd` direction of the port is a `()` or other unit type defined by `TrivialBwd`.

It does so by replacing all `Bwd` expressions with `unitBwd` from a `TrivialBwd` typeclass (Note: we might want to change this to be called `UnitC` or something). The above is desugared into something similar to:
```haskell
testDupCircuit = \(x_Fwd :-> (_,_)) -> unitBwd :-> (x_Fwd, x_Fwd) 
```


We could imagine a more general version of this which allowed more complex circuits to be fanned out by using a typeclass:
```
class Fanout a where
  fanoutC :: Circuit a (Vec n a)
```
However I don't particularly like this as it would be inserting logic without any obvious indication. 