### PR TITLE
Tagged implementation

### DIFF
--- a/example/Example.hs
+++ b/example/Example.hs
@@ -36,7 +36,7 @@ module Example where
 
 import           Circuit
 
-import           Clash.Prelude (Signal, Vec (..))
+import           Clash.Prelude
 
 idCircuit :: Circuit a a
 idCircuit = idC
@@ -99,6 +99,12 @@ sigPat2 = circuit $ \(Signal a) -> do
 fwdCircuit :: Circuit (Vec 3 (Signal dom Int)) (Vec 3 (Signal dom Int))
 fwdCircuit = circuit $ \(Fwd x) -> do
   i <- idC -< Fwd (fmap (+1) x)
+  idC -< i
+
+fwdWithLetCircuit :: KnownNat n => Circuit (Vec n (Signal dom Int)) (Vec n (Signal dom Int))
+fwdWithLetCircuit = circuit $ \(Fwd x) -> do
+  let y = fmap (+1) x
+  i <- idC -< Fwd y
   idC -< i
 
 fstC :: Circuit (Signal domain a, Signal domain b) (Signal domain a)

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -88,12 +88,17 @@ sigExpr sig = circuit do
 -- sigPat :: (( Signal Int -> Signal Int ))
 sigPat :: Circuit (Signal domain Int) (Signal domain Int)
 sigPat = circuit $ \(Signal a) -> do
-  i <- (idC :: Circuit (Signal domain Int) (Signal domain Int)) -< Signal a
+  i <- idC -< Signal a
   idC -< i
 
 sigPat2 :: Circuit (Signal dom Int) (Signal dom Int)
 sigPat2 = circuit $ \(Signal a) -> do
   i <- (idC :: Circuit (Signal dom Int) (Signal dom Int)) -< Signal a
+  idC -< i
+
+fwdCircuit :: Circuit (Vec 3 (Signal dom Int)) (Vec 3 (Signal dom Int))
+fwdCircuit = circuit $ \(Fwd x) -> do
+  i <- idC -< Fwd (fmap (+1) x)
   idC -< i
 
 fstC :: Circuit (Signal domain a, Signal domain b) (Signal domain a)

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -152,16 +152,16 @@ dupSignalC1 = circuit $ \x -> do
 -- -- myDesire = Circuit (\(aM2S,bS2M) -> let
 -- --   (aM2S', bS2M') = runCircuit myCircuit (aM2S, bS2M)
 -- --   in (aM2S', bS2M'))
-
+--
 -- -- var :: (Int, Int)
 -- -- var = (3, 5)
-
+--
 -- -- myLet :: Int
 -- -- myLet = let (yo, yo') = var in yo
-
+--
 -- -- ah :: (Int,Int)
 -- -- ah = (7,11)
-
+--
 -- -- tupCir1 :: Circuit (Int, Char) (Char, Int)
 -- -- tupCir1 = circuit \ input -> do
 -- --   (c,i) <- swapC @Int -< input
@@ -170,7 +170,7 @@ dupSignalC1 = circuit $ \x -> do
 -- --   c' <- myCircuitRev -< c
 -- --   c'' <- myIdCircuit -< c'
 -- --   idC -< (i', c'')
-
+--
 -- tupleCircuit :: Circuit Int Char
 -- tupleCircuit = id $ circuit \a -> do
 --   let b = 3
@@ -179,7 +179,7 @@ dupSignalC1 = circuit $ \x -> do
 --   b' <- myCircuit -< a'
 --   b'' <- (circuit \aa -> do idC -< aa) -< b'
 --   idC -< b''
-
+--
 -- -- simpleCircuit :: Circuit Int Char
 -- -- simpleCircuit = id $ circuit \a -> do
 -- --   b <- (circuit \a -> do b <- myCircuit -< a;idC -< b) -< a
@@ -187,7 +187,7 @@ dupSignalC1 = circuit $ \x -> do
 -- --   b' <- myCircuit -< a'
 -- --   b'' <- (circuit \aa -> do idC -< aa) -< b'
 -- --   idC -< b''
-
+--
 -- myCircuit :: Int
 -- myCircuit = circuit \(v1 :: DF d a) (v3 :: blah) -> do
 --   v1' <- total -< (v3 :: DF domain Int) -< (v4 :: DF domain Int)
@@ -196,39 +196,39 @@ dupSignalC1 = circuit $ \x -> do
 --   -- v2' <- total2 -< v2
 --   -- v3 <- zipC -< (v1', v2')
 --   v1 <- idC -< v3
-
+--
 -- -- type RunCircuit a b = (Circuit a b -> (M2S a, S2M b) -> (M2S b, S2M a))
 -- -- type CircuitId a b = Circuit a b -> Circuit a b
-
+--
 -- -- myCircuit = let
 -- --   _circuits :: (RunCircuit a b, RunCircuit c d, RunCircuit (b,d) e, CircuitId (a,c) e)
 -- --   _circuits@(runC1, runC2, runC2, cId) = (runCircuit, runCircuit, runCircuit, id)
-
+--
 -- --   in cId $ Circuit $ \((v1M2S, v2M2S),outputS2M) -> let
-
+--
 -- --   (v1'M2S, v1S2M) = runC1 total (v1M2s, v1'S2M)
 -- --   (v2'M2S, v2S2M) = runC2 total2 (v2M2s, v2'S2M)
 -- --   (v3M2S, (v1'S2M, v2'S2M)) = runC3 zipC ((v1'M2S, v2'M2S), v3S2M)
-
+--
 -- --   in (v3M2S, (v1S2M, v2S2M))
-
-
-
-
+--
+--
+--
+--
 --   -- circuitHelper
 --   --   :: Circuit a b
 --   --   -> Circuit c d
 --   --   -> Circuit (b,d) e
-
-
+--
+--
 -- -- myCircuit :: Int
 -- -- myCircuit = circuit (\(v1,v2) -> (v2,v1))
-
+--
 -- -- myCircuit :: Int
 -- -- myCircuit = circuit do
 -- --   (v2,v1) <- yeah
 -- --   idC -< (v1, v2)
-
+--
 -- -- myCircuit = proc v1 -> do
 -- --   x <- total -< value
 --   -- fin -< a

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -133,6 +133,21 @@ unfstC3 = circuit $ \a -> do
   ab' <- idC -< ab
   idC -< ab'
 
+-- a version of `idC` on `Signal domain Int` which has bad type inference.
+idCHard
+  :: (Fwd a ~ Signal domain Int, Bwd a ~ (), Fwd b ~ Signal domain Int, Bwd b ~ ())
+  => Circuit a b
+idCHard = Circuit $ \ (aFwd :-> ()) -> () :-> aFwd
+
+typedBus1 :: forall domain . Circuit (Signal domain Int) (Signal domain Int)
+typedBus1 = circuit $ \a -> do
+  (b :: Signal domain Int) <- idCHard -< a
+  idCHard -< b
+
+typedBus2 :: forall domain . Circuit (Signal domain Int) (Signal domain Int)
+typedBus2 = circuit $ \a -> do
+  b <- idCHard -< a
+  idCHard -< (b :: Signal domain Int)
 
 swapTest :: forall a b. Circuit (a,b) (b,a)
 -- swapTest = circuit $ \(a,b) -> (idCircuit :: Circuit (b, a) (b, a)) -< (b, a)

--- a/shell.nix
+++ b/shell.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation {
 
   buildInputs = [
     ghc
-    # cabal-install
-    # haskellPackages.ghcid
+    cabal-install
+    haskellPackages.ghcid
     haskellPackages.stylish-haskell
   ];
 

--- a/src/Circuit.hs
+++ b/src/Circuit.hs
@@ -74,12 +74,9 @@ newtype Circuit a b = Circuit { runCircuit :: CircuitT a b }
 type CircuitT a b = (Fwd a :-> Bwd b) -> (Bwd a :-> Fwd b)
 
 
-type TagCircuitT a b = (BusTagFwd a :-> BusTagBwd b) -> (BusTagBwd a :-> BusTagFwd b)
+type TagCircuitT a b = (BusTag a (Fwd a) :-> BusTag b (Bwd b)) -> (BusTag a (Bwd a) :-> BusTag b (Fwd b))
 
 newtype BusTag t b = BusTag {unBusTag :: b}
-
-type BusTagFwd a = BusTag a (Fwd a)
-type BusTagBwd a = BusTag a (Bwd a)
 
 mkTagCircuit :: TagCircuitT a b -> Circuit a b
 mkTagCircuit f = Circuit $ \ (aFwd :-> bBwd) -> let
@@ -201,3 +198,4 @@ instance BusTagBundle (Vec n t) (Vec n a) where
 pattern BusTagBundle :: BusTagBundle t a => BusTagUnbundled t a -> BusTag t a
 pattern BusTagBundle a <- (taggedUnbundle -> a) where
   BusTagBundle a = taggedBundle a
+{-# COMPLETE BusTagBundle #-}

--- a/src/Circuit.hs
+++ b/src/Circuit.hs
@@ -74,22 +74,22 @@ newtype Circuit a b = Circuit { runCircuit :: CircuitT a b }
 type CircuitT a b = (Fwd a :-> Bwd b) -> (Bwd a :-> Fwd b)
 
 
-type TagCircuitT a b = (TagFwd a :-> TagBwd b) -> (TagBwd a :-> TagFwd b)
+type TagCircuitT a b = (BusTagFwd a :-> BusTagBwd b) -> (BusTagBwd a :-> BusTagFwd b)
 
-newtype Tag t b = Tag {unTag :: b}
+newtype BusTag t b = BusTag {unBusTag :: b}
 
-type TagFwd a = Tag a (Fwd a)
-type TagBwd a = Tag a (Bwd a)
+type BusTagFwd a = BusTag a (Fwd a)
+type BusTagBwd a = BusTag a (Bwd a)
 
 mkTagCircuit :: TagCircuitT a b -> Circuit a b
 mkTagCircuit f = Circuit $ \ (aFwd :-> bBwd) -> let
-    (Tag aBwd :-> Tag bFwd) = f (Tag aFwd :-> Tag bBwd)
+    (BusTag aBwd :-> BusTag bFwd) = f (BusTag aFwd :-> BusTag bBwd)
   in (aBwd :-> bFwd)
 
 runTagCircuit :: Circuit a b -> TagCircuitT a b
 runTagCircuit (Circuit c) (aFwd :-> bBwd) = let
-    (aBwd :-> bFwd) = c (unTag aFwd :-> unTag bBwd)
-  in (Tag aBwd :-> Tag bFwd)
+    (aBwd :-> bFwd) = c (unBusTag aFwd :-> unBusTag bBwd)
+  in (BusTag aBwd :-> BusTag bFwd)
 
 pattern TagCircuit :: TagCircuitT a b -> Circuit a b
 pattern TagCircuit f <- (runTagCircuit -> f) where
@@ -135,69 +135,69 @@ instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e, 
 instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e, TrivialBwd f, TrivialBwd g, TrivialBwd h, TrivialBwd i, TrivialBwd j) => TrivialBwd (a,b,c,d,e,f,g,h,i,j) where
   unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd)
 
-instance TrivialBwd a => TrivialBwd (Tag t a) where
-  unitBwd = Tag unitBwd
+instance TrivialBwd a => TrivialBwd (BusTag t a) where
+  unitBwd = BusTag unitBwd
 
-class TagBundle t a where
-  type TagUnbundled t a = res | res -> t a
-  taggedBundle :: TagUnbundled t a -> Tag t a
-  taggedUnbundle :: Tag t a -> TagUnbundled t a
+class BusTagBundle t a where
+  type BusTagUnbundled t a = res | res -> t a
+  taggedBundle :: BusTagUnbundled t a -> BusTag t a
+  taggedUnbundle :: BusTag t a -> BusTagUnbundled t a
 
-instance TagBundle () () where
-  type TagUnbundled () () = ()
-  taggedBundle = Tag
-  taggedUnbundle = unTag
+instance BusTagBundle () () where
+  type BusTagUnbundled () () = ()
+  taggedBundle = BusTag
+  taggedUnbundle = unBusTag
 
-instance TagBundle (ta, tb) (a, b) where
-  type TagUnbundled (ta, tb) (a, b) = (Tag ta a, Tag tb b)
-  taggedBundle (Tag a, Tag b) = Tag (a, b)
-  taggedUnbundle (Tag (a, b)) =  (Tag a, Tag b)
+instance BusTagBundle (ta, tb) (a, b) where
+  type BusTagUnbundled (ta, tb) (a, b) = (BusTag ta a, BusTag tb b)
+  taggedBundle (BusTag a, BusTag b) = BusTag (a, b)
+  taggedUnbundle (BusTag (a, b)) =  (BusTag a, BusTag b)
 
-instance TagBundle (ta, tb, tc) (a, b, c) where
-  type TagUnbundled (ta, tb, tc) (a, b, c) = (Tag ta a, Tag tb b, Tag tc c)
-  taggedBundle (Tag a, Tag b, Tag c) = Tag (a, b, c)
-  taggedUnbundle (Tag (a, b, c)) =  (Tag a, Tag b, Tag c)
+instance BusTagBundle (ta, tb, tc) (a, b, c) where
+  type BusTagUnbundled (ta, tb, tc) (a, b, c) = (BusTag ta a, BusTag tb b, BusTag tc c)
+  taggedBundle (BusTag a, BusTag b, BusTag c) = BusTag (a, b, c)
+  taggedUnbundle (BusTag (a, b, c)) =  (BusTag a, BusTag b, BusTag c)
 
-instance TagBundle (ta, tb, tc, td) (a, b, c, d) where
-  type TagUnbundled (ta, tb, tc, td) (a, b, c, d) = (Tag ta a, Tag tb b, Tag tc c, Tag td d)
-  taggedBundle (Tag a, Tag b, Tag c, Tag d) = Tag (a, b, c, d)
-  taggedUnbundle (Tag (a, b, c, d)) =  (Tag a, Tag b, Tag c, Tag d)
+instance BusTagBundle (ta, tb, tc, td) (a, b, c, d) where
+  type BusTagUnbundled (ta, tb, tc, td) (a, b, c, d) = (BusTag ta a, BusTag tb b, BusTag tc c, BusTag td d)
+  taggedBundle (BusTag a, BusTag b, BusTag c, BusTag d) = BusTag (a, b, c, d)
+  taggedUnbundle (BusTag (a, b, c, d)) =  (BusTag a, BusTag b, BusTag c, BusTag d)
 
-instance TagBundle (ta, tb, tc, td, te) (a, b, c, d, e) where
-  type TagUnbundled (ta, tb, tc, td, te) (a, b, c, d, e) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e)
-  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e) = Tag (a, b, c, d, e)
-  taggedUnbundle (Tag (a, b, c, d, e)) =  (Tag a, Tag b, Tag c, Tag d, Tag e)
+instance BusTagBundle (ta, tb, tc, td, te) (a, b, c, d, e) where
+  type BusTagUnbundled (ta, tb, tc, td, te) (a, b, c, d, e) = (BusTag ta a, BusTag tb b, BusTag tc c, BusTag td d, BusTag te e)
+  taggedBundle (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e) = BusTag (a, b, c, d, e)
+  taggedUnbundle (BusTag (a, b, c, d, e)) =  (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e)
 
-instance TagBundle (ta, tb, tc, td, te, tf) (a, b, c, d, e, f) where
-  type TagUnbundled (ta, tb, tc, td, te, tf) (a, b, c, d, e, f) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f)
-  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f) = Tag (a, b, c, d, e, f)
-  taggedUnbundle (Tag (a, b, c, d, e, f)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f)
+instance BusTagBundle (ta, tb, tc, td, te, tf) (a, b, c, d, e, f) where
+  type BusTagUnbundled (ta, tb, tc, td, te, tf) (a, b, c, d, e, f) = (BusTag ta a, BusTag tb b, BusTag tc c, BusTag td d, BusTag te e, BusTag tf f)
+  taggedBundle (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f) = BusTag (a, b, c, d, e, f)
+  taggedUnbundle (BusTag (a, b, c, d, e, f)) =  (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f)
 
-instance TagBundle (ta, tb, tc, td, te, tf, tg) (a, b, c, d, e, f, g) where
-  type TagUnbundled (ta, tb, tc, td, te, tf, tg) (a, b, c, d, e, f, g) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f, Tag tg g)
-  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g) = Tag (a, b, c, d, e, f, g)
-  taggedUnbundle (Tag (a, b, c, d, e, f, g)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g)
+instance BusTagBundle (ta, tb, tc, td, te, tf, tg) (a, b, c, d, e, f, g) where
+  type BusTagUnbundled (ta, tb, tc, td, te, tf, tg) (a, b, c, d, e, f, g) = (BusTag ta a, BusTag tb b, BusTag tc c, BusTag td d, BusTag te e, BusTag tf f, BusTag tg g)
+  taggedBundle (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f, BusTag g) = BusTag (a, b, c, d, e, f, g)
+  taggedUnbundle (BusTag (a, b, c, d, e, f, g)) =  (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f, BusTag g)
 
-instance TagBundle (ta, tb, tc, td, te, tf, tg, th) (a, b, c, d, e, f, g, h) where
-  type TagUnbundled (ta, tb, tc, td, te, tf, tg, th) (a, b, c, d, e, f, g, h) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f, Tag tg g, Tag th h)
-  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h) = Tag (a, b, c, d, e, f, g, h)
-  taggedUnbundle (Tag (a, b, c, d, e, f, g, h)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h)
+instance BusTagBundle (ta, tb, tc, td, te, tf, tg, th) (a, b, c, d, e, f, g, h) where
+  type BusTagUnbundled (ta, tb, tc, td, te, tf, tg, th) (a, b, c, d, e, f, g, h) = (BusTag ta a, BusTag tb b, BusTag tc c, BusTag td d, BusTag te e, BusTag tf f, BusTag tg g, BusTag th h)
+  taggedBundle (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f, BusTag g, BusTag h) = BusTag (a, b, c, d, e, f, g, h)
+  taggedUnbundle (BusTag (a, b, c, d, e, f, g, h)) =  (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f, BusTag g, BusTag h)
 
-instance TagBundle (ta, tb, tc, td, te, tf, tg, th, ti) (a, b, c, d, e, f, g, h, i) where
-  type TagUnbundled (ta, tb, tc, td, te, tf, tg, th, ti) (a, b, c, d, e, f, g, h, i) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f, Tag tg g, Tag th h, Tag ti i)
-  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h, Tag i) = Tag (a, b, c, d, e, f, g, h, i)
-  taggedUnbundle (Tag (a, b, c, d, e, f, g, h, i)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h, Tag i)
+instance BusTagBundle (ta, tb, tc, td, te, tf, tg, th, ti) (a, b, c, d, e, f, g, h, i) where
+  type BusTagUnbundled (ta, tb, tc, td, te, tf, tg, th, ti) (a, b, c, d, e, f, g, h, i) = (BusTag ta a, BusTag tb b, BusTag tc c, BusTag td d, BusTag te e, BusTag tf f, BusTag tg g, BusTag th h, BusTag ti i)
+  taggedBundle (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f, BusTag g, BusTag h, BusTag i) = BusTag (a, b, c, d, e, f, g, h, i)
+  taggedUnbundle (BusTag (a, b, c, d, e, f, g, h, i)) =  (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f, BusTag g, BusTag h, BusTag i)
 
-instance TagBundle (ta, tb, tc, td, te, tf, tg, th, ti, tj) (a, b, c, d, e, f, g, h, i, j) where
-  type TagUnbundled (ta, tb, tc, td, te, tf, tg, th, ti, tj) (a, b, c, d, e, f, g, h, i, j) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f, Tag tg g, Tag th h, Tag ti i, Tag tj j)
-  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h, Tag i, Tag j) = Tag (a, b, c, d, e, f, g, h, i, j)
-  taggedUnbundle (Tag (a, b, c, d, e, f, g, h, i, j)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h, Tag i, Tag j)
+instance BusTagBundle (ta, tb, tc, td, te, tf, tg, th, ti, tj) (a, b, c, d, e, f, g, h, i, j) where
+  type BusTagUnbundled (ta, tb, tc, td, te, tf, tg, th, ti, tj) (a, b, c, d, e, f, g, h, i, j) = (BusTag ta a, BusTag tb b, BusTag tc c, BusTag td d, BusTag te e, BusTag tf f, BusTag tg g, BusTag th h, BusTag ti i, BusTag tj j)
+  taggedBundle (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f, BusTag g, BusTag h, BusTag i, BusTag j) = BusTag (a, b, c, d, e, f, g, h, i, j)
+  taggedUnbundle (BusTag (a, b, c, d, e, f, g, h, i, j)) =  (BusTag a, BusTag b, BusTag c, BusTag d, BusTag e, BusTag f, BusTag g, BusTag h, BusTag i, BusTag j)
 
-instance TagBundle (Vec n t) (Vec n a) where
-  type TagUnbundled (Vec n t) (Vec n a) = Vec n (Tag t a)
-  taggedBundle = Tag . fmap unTag
-  taggedUnbundle = fmap Tag . unTag
+instance BusTagBundle (Vec n t) (Vec n a) where
+  type BusTagUnbundled (Vec n t) (Vec n a) = Vec n (BusTag t a)
+  taggedBundle = BusTag . fmap unBusTag
+  taggedUnbundle = fmap BusTag . unBusTag
 
-pattern TagBundle :: TagBundle t a => TagUnbundled t a -> Tag t a
-pattern TagBundle a <- (taggedUnbundle -> a) where
-  TagBundle a = taggedBundle a
+pattern BusTagBundle :: BusTagBundle t a => BusTagUnbundled t a -> BusTag t a
+pattern BusTagBundle a <- (taggedUnbundle -> a) where
+  BusTagBundle a = taggedBundle a

--- a/src/Circuit.hs
+++ b/src/Circuit.hs
@@ -123,14 +123,30 @@ instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e) 
 instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e, TrivialBwd f) => TrivialBwd (a,b,c,d,e,f) where
   unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd)
 
+instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e, TrivialBwd f, TrivialBwd g) => TrivialBwd (a,b,c,d,e,f,g) where
+  unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd)
+
+instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e, TrivialBwd f, TrivialBwd g, TrivialBwd h) => TrivialBwd (a,b,c,d,e,f,g,h) where
+  unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd)
+
+instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e, TrivialBwd f, TrivialBwd g, TrivialBwd h, TrivialBwd i) => TrivialBwd (a,b,c,d,e,f,g,h,i) where
+  unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd)
+
+instance (TrivialBwd a, TrivialBwd b, TrivialBwd c, TrivialBwd d, TrivialBwd e, TrivialBwd f, TrivialBwd g, TrivialBwd h, TrivialBwd i, TrivialBwd j) => TrivialBwd (a,b,c,d,e,f,g,h,i,j) where
+  unitBwd = (unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd, unitBwd)
+
 instance TrivialBwd a => TrivialBwd (Tag t a) where
   unitBwd = Tag unitBwd
-
 
 class TagBundle t a where
   type TagUnbundled t a = res | res -> t a
   taggedBundle :: TagUnbundled t a -> Tag t a
   taggedUnbundle :: Tag t a -> TagUnbundled t a
+
+instance TagBundle () () where
+  type TagUnbundled () () = ()
+  taggedBundle = Tag
+  taggedUnbundle = unTag
 
 instance TagBundle (ta, tb) (a, b) where
   type TagUnbundled (ta, tb) (a, b) = (Tag ta a, Tag tb b)
@@ -142,6 +158,41 @@ instance TagBundle (ta, tb, tc) (a, b, c) where
   taggedBundle (Tag a, Tag b, Tag c) = Tag (a, b, c)
   taggedUnbundle (Tag (a, b, c)) =  (Tag a, Tag b, Tag c)
 
+instance TagBundle (ta, tb, tc, td) (a, b, c, d) where
+  type TagUnbundled (ta, tb, tc, td) (a, b, c, d) = (Tag ta a, Tag tb b, Tag tc c, Tag td d)
+  taggedBundle (Tag a, Tag b, Tag c, Tag d) = Tag (a, b, c, d)
+  taggedUnbundle (Tag (a, b, c, d)) =  (Tag a, Tag b, Tag c, Tag d)
+
+instance TagBundle (ta, tb, tc, td, te) (a, b, c, d, e) where
+  type TagUnbundled (ta, tb, tc, td, te) (a, b, c, d, e) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e)
+  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e) = Tag (a, b, c, d, e)
+  taggedUnbundle (Tag (a, b, c, d, e)) =  (Tag a, Tag b, Tag c, Tag d, Tag e)
+
+instance TagBundle (ta, tb, tc, td, te, tf) (a, b, c, d, e, f) where
+  type TagUnbundled (ta, tb, tc, td, te, tf) (a, b, c, d, e, f) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f)
+  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f) = Tag (a, b, c, d, e, f)
+  taggedUnbundle (Tag (a, b, c, d, e, f)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f)
+
+instance TagBundle (ta, tb, tc, td, te, tf, tg) (a, b, c, d, e, f, g) where
+  type TagUnbundled (ta, tb, tc, td, te, tf, tg) (a, b, c, d, e, f, g) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f, Tag tg g)
+  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g) = Tag (a, b, c, d, e, f, g)
+  taggedUnbundle (Tag (a, b, c, d, e, f, g)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g)
+
+instance TagBundle (ta, tb, tc, td, te, tf, tg, th) (a, b, c, d, e, f, g, h) where
+  type TagUnbundled (ta, tb, tc, td, te, tf, tg, th) (a, b, c, d, e, f, g, h) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f, Tag tg g, Tag th h)
+  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h) = Tag (a, b, c, d, e, f, g, h)
+  taggedUnbundle (Tag (a, b, c, d, e, f, g, h)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h)
+
+instance TagBundle (ta, tb, tc, td, te, tf, tg, th, ti) (a, b, c, d, e, f, g, h, i) where
+  type TagUnbundled (ta, tb, tc, td, te, tf, tg, th, ti) (a, b, c, d, e, f, g, h, i) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f, Tag tg g, Tag th h, Tag ti i)
+  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h, Tag i) = Tag (a, b, c, d, e, f, g, h, i)
+  taggedUnbundle (Tag (a, b, c, d, e, f, g, h, i)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h, Tag i)
+
+instance TagBundle (ta, tb, tc, td, te, tf, tg, th, ti, tj) (a, b, c, d, e, f, g, h, i, j) where
+  type TagUnbundled (ta, tb, tc, td, te, tf, tg, th, ti, tj) (a, b, c, d, e, f, g, h, i, j) = (Tag ta a, Tag tb b, Tag tc c, Tag td d, Tag te e, Tag tf f, Tag tg g, Tag th h, Tag ti i, Tag tj j)
+  taggedBundle (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h, Tag i, Tag j) = Tag (a, b, c, d, e, f, g, h, i, j)
+  taggedUnbundle (Tag (a, b, c, d, e, f, g, h, i, j)) =  (Tag a, Tag b, Tag c, Tag d, Tag e, Tag f, Tag g, Tag h, Tag i, Tag j)
+
 instance TagBundle (Vec n t) (Vec n a) where
   type TagUnbundled (Vec n t) (Vec n a) = Vec n (Tag t a)
   taggedBundle = Tag . fmap unTag
@@ -150,8 +201,3 @@ instance TagBundle (Vec n t) (Vec n a) where
 pattern TagBundle :: TagBundle t a => TagUnbundled t a -> Tag t a
 pattern TagBundle a <- (taggedUnbundle -> a) where
   TagBundle a = taggedBundle a
-
-instance TagBundle () () where
-  type TagUnbundled () () = ()
-  taggedBundle = Tag
-  taggedUnbundle = unTag

--- a/src/CircuitNotation.hs
+++ b/src/CircuitNotation.hs
@@ -1122,8 +1122,8 @@ defExternalNames :: ExternalNames
 defExternalNames = ExternalNames
   { circuitCon = GHC.Unqual (OccName.mkDataOcc "TagCircuit")
   , runCircuitName = GHC.Unqual (OccName.mkVarOcc "runTagCircuit")
-  , tagBundlePat = GHC.Unqual (OccName.mkDataOcc "TagBundle")
-  , tagName = GHC.Unqual (OccName.mkDataOcc "Tag")
+  , tagBundlePat = GHC.Unqual (OccName.mkDataOcc "BusTagBundle")
+  , tagName = GHC.Unqual (OccName.mkDataOcc "BusTag")
   , fwdBwdCon = GHC.Unqual (OccName.mkDataOcc ":->")
   , trivialBwd = GHC.Unqual (OccName.mkVarOcc "unitBwd")
   }

--- a/src/CircuitNotation.hs
+++ b/src/CircuitNotation.hs
@@ -811,7 +811,7 @@ bindWithSuffix dflags dir = \case
   FwdExpr (L l _) -> L l (WildPat noExt)
 #endif
   FwdPat lpat -> tagP lpat
-  PortType ty p -> tagTypeP dir ty $ bindWithSuffix dflags dir p
+  PortType _ty p -> bindWithSuffix dflags dir p
 
 revDirec :: Direction -> Direction
 revDirec = \case


### PR DESCRIPTION
This is a work in progress rework of the type inference solution to use a "Tagged" implementation: 
```
type TagCircuitT a b = (TagFwd a :-> TagBwd b) -> (TagBwd a :-> TagFwd b)

newtype Tag t b = Tag {unTag :: b}

type TagFwd a = Tag a (Fwd a)
type TagBwd a = Tag a (Bwd a)

pattern TagCircuit :: TagCircuitT a b -> Circuit a b
pattern TagCircuit f <- (runTagCircuit -> f) where
  TagCircuit f = mkTagCircuit f
```

With circuits passing around these Tagged types which include the type of the `Bus`. This has a major advantage for type inference because it can use the type of pre-defined circuits e.g.:
```
runTagCircuit idC :: (TagFwd a :-> TagBwd a) -> (TagFwd a :-> TagBwd a)
```
Which means the type of input & output (`a`) can be unified.

# Generated Code

This meas the generated code no longer needs the `inferenceHelper` and can be just written with `Tagged` stuff:
```
swapC2 :: Circuit (a,b) (b,a)
swapC2 = circuit $ \ (a,b) -> (b,a)
```
results in:
```
swapC = TagCircuit
  (\ (~(TagBundle (a_Fwd, b_Fwd)) :-> ~(TagBundle (b_Bwd, a_Bwd)))
     -> let in TagBundle (a_Bwd, b_Bwd) :-> TagBundle (b_Fwd, a_Fwd))
```

# TaggedBundle

The main challenge is we need to bundle up typed elements. Consider for example:
```
circuit $ \(a,b) -> do
  idC -< (b, a)
```
We will be given `TagFwd (a,b)` but we need `TagFwd a` and `TagFwd b`. We do this using a `Tag` bundle class which seems to work nicely in practice.

This only needs to support the types with special support in `Circuit` notation i.e. tuples, unit and vec