### PR TITLE
Export `Direction(..)` from `CircuitNotation`

### DIFF
--- a/src/CircuitNotation.hs
+++ b/src/CircuitNotation.hs
@@ -36,6 +36,7 @@ module CircuitNotation
   , mkPlugin
   , thName
   , ExternalNames (..)
+  , Direction(..)
   ) where
 
 -- base


### PR DESCRIPTION
Hard to implement `ExternalNames` without it :-)