### PR TITLE
Use Void typeclass instead of Default for underscored circuits

### DIFF
--- a/src/Circuit.hs
+++ b/src/Circuit.hs
@@ -54,10 +54,22 @@ data DF (dom :: Domain)  a
 data DFM2S a = DFM2S Bool a
 newtype DFS2M = DFS2M Bool
 
-instance Default (DFM2S a) where
-  def = DFM2S False (error "error default")
-instance Default DFS2M where
-  def = DFS2M True
+-- | For /dev/null-like circuits: always acknowledge incoming data
+--   while never sending out data. Used for ignoring streams with an underscore prefix.
+class Void a where
+  driveVoid :: a
+
+instance Void () where
+  driveVoid = ()
+
+instance (Void a) => Void (Signal dom a) where
+  driveVoid = pure driveVoid
+
+instance Void (DFM2S a) where
+  driveVoid = DFM2S False (error "void")
+
+instance Void DFS2M where
+  driveVoid = DFS2M True
 
 type instance Fwd (DF dom a) = Signal dom (DFM2S a)
 type instance Bwd (DF dom a) = Signal dom DFS2M

--- a/src/CircuitNotation.hs
+++ b/src/CircuitNotation.hs
@@ -42,7 +42,6 @@ module CircuitNotation
 -- base
 import           Control.Exception
 import qualified Data.Data              as Data
-import           Data.Default
 import           Data.Maybe             (fromMaybe)
 #if __GLASGOW_HASKELL__ >= 900
 #else
@@ -1176,7 +1175,7 @@ completeUnderscores = do
   let addDef :: String -> PortDescription PortName -> CircuitM ()
       addDef suffix = \case
         Ref (PortName loc (unpackFS -> name@('_':_))) -> do
-          let bind = patBind (varP loc (name <> suffix)) (tagE $ varE loc (thName 'def))
+          let bind = patBind (varP loc (name <> suffix)) (tagE $ varE loc (driveVoid ?nms))
           circuitLets <>= [L loc bind]
 
         _ -> pure ()
@@ -1186,7 +1185,6 @@ completeUnderscores = do
         L.traverseOf_ L.cosmos (addDef "_Bwd") bIn
   mapM_ addBind binds
   addBind (Binding undefined masters slaves)
-
 
 -- | Transform declarations in the module by converting circuit blocks.
 transform
@@ -1321,6 +1319,7 @@ data ExternalNames = ExternalNames
   , fwdBwdCon :: GHC.RdrName
   , fwdAndBwdTypes :: Direction -> GHC.RdrName
   , trivialBwd :: GHC.RdrName
+  , driveVoid :: GHC.RdrName
   , consPat :: GHC.RdrName
   }
 
@@ -1335,6 +1334,7 @@ defExternalNames = ExternalNames
   , fwdAndBwdTypes = \case
       Fwd -> GHC.Unqual (OccName.mkTcOcc "Fwd")
       Bwd -> GHC.Unqual (OccName.mkTcOcc "Bwd")
+  , driveVoid = GHC.Unqual (OccName.mkVarOcc "driveVoid")
   , trivialBwd = GHC.Unqual (OccName.mkVarOcc "unitBwd")
 #if __GLASGOW_HASKELL__ > 900
   , consPat = GHC.Unqual (OccName.mkDataOcc ":>!")


### PR DESCRIPTION
See https://github.com/clash-lang/clash-protocols/issues/92. Feel free to suggest different different names for the typeclass/functions. 