### PR TITLE
Nix use clash-compiler GHC version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.6"]
+        cabal: ["latest"]
         ghc:
           - "8.6.5"
           - "8.10.7"

--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1752917053,
-        "narHash": "sha256-oI4b1MZ1MR7WLeyZw9k/g6P+707i7RMhdMxkSIBga2Q=",
+        "lastModified": 1753722205,
+        "narHash": "sha256-tfBkzRbiYVX6f0oSnY86Uem/JSsCmYXfAJxW+ZKmWQk=",
         "owner": "clash-lang",
         "repo": "clash-compiler",
-        "rev": "229f243605f5ac88fc4e65076acec650ce1164df",
+        "rev": "43a1c722af29f34c6faf18f14e6cf46a3cfba80f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         # What version of the GHC compiler to use
-        compiler-version = "ghc910";
+        compiler-version = clash-compiler.ghcVersion.${system};
 
         pkgs = (import clash-compiler.inputs.nixpkgs {
           inherit system;
@@ -26,7 +26,7 @@
       {
         # Expose the overlay which adds circuit-notation
         # The base of the overlay is clash-pkgs
-        overlay = overlay;
+        overlays.default = overlay;
 
         devShells.default = hs-pkgs.shellFor {
           packages = p: [


### PR DESCRIPTION
Rather than use a predefined local version of GHC, use the same version the clash compiler uses. This makes it so the flake doesn't have to get independently updated and can just follow whatever clash-compiler has.

This change has been made to following the decision to pin clash-compiler to a minor version of GHC. Changing minor versions for each project depending on clash-compiler will be tedious, so this will make it automatically follow the same version of clash-compiler.

Marked as draft until https://github.com/clash-lang/clash-compiler/pull/2984 is merged.

## TODO:
- [x] Update flake.lock (depends on PR)