### PR TITLE
Nix build circuit-notation for all Clash-GHC supported versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1753722205,
-        "narHash": "sha256-tfBkzRbiYVX6f0oSnY86Uem/JSsCmYXfAJxW+ZKmWQk=",
+        "lastModified": 1754301255,
+        "narHash": "sha256-dne2oWxOEosMYumUZZhc3c8NyJMdiqpb/xvd1saTp30=",
         "owner": "clash-lang",
         "repo": "clash-compiler",
-        "rev": "43a1c722af29f34c6faf18f14e6cf46a3cfba80f",
+        "rev": "6a0810496560e2ff2a0071f315afb573c12bba39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Instead of only building the default version clash-compiler supports, it will now expose builds for all available supported clash-compiler versions.

This is a followup for the issue mentioned:
https://github.com/clash-lang/clash-compiler/pull/2987