### PR TITLE
Fix dropping of error locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for `circuit-notations`
 
+## Unreleased
+
+* Fix the source location of type errors on a bus. Since bus tagging was
+  introduced, such errors pointed at the end of the `circuit` block rather than
+  at the offending statement. Generated bindings are now located at their
+  circuit expression so GHC blames the right line.
+
 ## 0.2.0.0 -- 2026-04-23
 
 * Start of the changelog

--- a/circuit-notation.cabal
+++ b/circuit-notation.cabal
@@ -71,3 +71,18 @@ test-suite library-testsuite
     base,
     circuit-notation,
     clash-prelude >=1.0,
+
+-- Checks that type errors on a bus point at the offending statement rather than
+-- at the end of the circuit (see tests/fixtures/BusError.hs).
+test-suite error-location
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  main-is: error-location.hs
+  hs-source-dirs: tests
+  build-depends:
+    base,
+    circuit-notation,
+    clash-prelude >=1.0,
+    directory,
+    filepath,
+    process,

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,18 @@
               circuit-notation = prev.developPackage {
                 root = ./.;
                 overrides = _: _: final;
+                # The error-location test shells out to `ghc` to compile a
+                # fixture with the plugin enabled (see tests/error-location.hs).
+                # During the package's own check phase circuit-notation isn't
+                # registered in any package database yet, so that `ghc` couldn't
+                # find the plugin. Point GHC_PACKAGE_PATH (via the builder's
+                # NIX_GHC_PACKAGE_PATH_FOR_TEST hook) at the in-place package db
+                # so the test runs for real, not just under cabal in CI.
+                modifier = drv: drv.overrideAttrs (old: {
+                  preCheck = (old.preCheck or "") + ''
+                    export NIX_GHC_PACKAGE_PATH_FOR_TEST="$PWD/dist/package.conf.inplace:$packageConfDir:"
+                  '';
+                });
               };
             };
           in

--- a/src/CircuitNotation.hs
+++ b/src/CircuitNotation.hs
@@ -980,8 +980,12 @@ circuitQQExpM = do
   slaves <- L.use circuitSlaves
   masters <- L.use circuitMasters
 
-  -- Construction of the circuit expression
-  let decs = lets <> map (noLoc . decFromBinding dflags) binds
+  -- Construction of the circuit expression.
+  -- Locate each generated binding at its circuit expression so that type
+  -- errors on a bus are reported on the offending statement rather than at
+  -- the end of the circuit block (see tests/fixtures/BusError.hs).
+  let decFromBinding' b@Binding{bCircuit = L cloc _} = L cloc (decFromBinding dflags b)
+  let decs = lets <> map decFromBinding' binds
 
   let pats = bindOutputs dflags Fwd masters slaves
       res  = createInputs Bwd slaves masters

--- a/tests/error-location.hs
+++ b/tests/error-location.hs
@@ -1,0 +1,91 @@
+-- | Regression test for the source locations of type errors on buses.
+--
+-- When bus tagging (the @BusTag@ wrapping) was introduced, type errors on a
+-- bus stopped pointing at the offending statement and instead pointed at the
+-- end of the @circuit@ block, which made them very hard to act on.
+--
+-- This test compiles 'tests/fixtures/BusError.hs' (which has a deliberate type
+-- error on a bus, on the line marked @ERROR HERE@) with plugin enabled and
+-- asserts that GHC reports an error /on that line/. It uses the same plain
+-- @ghc@ + package-environment-file mechanism that CI already uses to compile
+-- the @Example@ module.
+module Main (main) where
+
+import           Control.Monad      (unless, when)
+import           Data.List          (isInfixOf, isPrefixOf, nub, sort)
+import           Data.Maybe         (mapMaybe)
+import           System.Directory   (getTemporaryDirectory)
+import           System.Environment (lookupEnv)
+import           System.Exit        (exitFailure)
+import           System.FilePath    ((</>))
+import           System.Process     (readProcessWithExitCode)
+import           Text.Read          (readMaybe)
+
+fixture :: FilePath
+fixture = "tests" </> "fixtures" </> "BusError.hs"
+
+-- | The marker placed on the erroring statement inside the fixture. It is
+-- chosen so that it appears on exactly one line of the fixture.
+marker :: String
+marker = "bus-error-marker"
+
+main :: IO ()
+main = do
+  src <- readFile fixture
+
+  -- Work out which line the deliberate error is on by finding the marker.
+  let markedLines =
+        [ n | (n, l) <- zip [1 :: Int ..] (lines src), marker `isInfixOf` l ]
+  expectedLine <- case markedLines of
+    [n] -> pure n
+    _   -> die $ "expected exactly one line containing " <> show marker
+                   <> " in " <> fixture <> ", found lines " <> show markedLines
+
+  -- Compile the fixture and collect the reported error lines.
+  ghc <- maybe "ghc" id <$> lookupEnv "GHC"
+  tmp <- getTemporaryDirectory
+  let args =
+        [ "-outputdir", tmp </> "circuit-notation-error-test"
+        , "-itests/fixtures"
+        , fixture
+        ]
+  (_code, out, err) <- readProcessWithExitCode ghc args ""
+  let output    = out <> err
+      errLines  = sort . nub $ errorLineNumbers output
+
+  putStrLn $ "ghc reported errors on lines: " <> show errLines
+  putStrLn $ "expected an error on line:    " <> show expectedLine
+
+  when (null errLines) $
+    die $ "expected the fixture to fail to compile, but ghc reported no\n\
+          \error locations. Full output:\n" <> output
+
+  unless (expectedLine `elem` errLines) $
+    die $ "type error on the bus was not reported on the offending line ("
+            <> show expectedLine <> ").\n"
+            <> "Instead it was reported on lines " <> show errLines
+            <> " -- this is the bus-tagging regression where errors point at\n"
+            <> "the end of the circuit rather than the actual mistake.\n\n"
+            <> "Full ghc output:\n" <> output
+
+  putStrLn "OK: bus type error points at the offending statement."
+
+-- | Extract the line numbers from GHC error messages that refer to the fixture,
+-- e.g. a line @tests/fixtures/BusError.hs:30:8: error: ...@ yields @30@.
+errorLineNumbers :: String -> [Int]
+errorLineNumbers = mapMaybe parseLine . lines
+  where
+    parseLine l = do
+      let l' = dropWhile (== ' ') l
+      rest <- stripFixturePrefix l'
+      let lineStr = takeWhile (/= ':') rest
+      readMaybe lineStr
+
+    stripFixturePrefix l
+      | (fixture <> ":") `isPrefixOf` l = Just (drop (length fixture + 1) l)
+      | otherwise                       = Nothing
+
+die :: String -> IO a
+die msg = do
+  putStrLn ("error-location test failed: " <> msg)
+  exitFailure

--- a/tests/fixtures/BusError.hs
+++ b/tests/fixtures/BusError.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS -fplugin=CircuitNotation #-}
+
+-- | A fixture that deliberately contains a type error on a bus, used by the
+-- error-location test. The error is on the statement tagged with the marker
+-- comment below: @boolC@ forces its input to be a
+-- @Signal dom Bool@, but the bus @b@ carries a @Signal dom Int@.
+--
+-- Crucially the erroring statement is /not/ the last statement of the circuit.
+-- Before bus tagging gained source locations, GHC blamed the final statement
+-- of the circuit (the @idC -< e@ line) instead of the actual mismatch, which
+-- made the error very hard to track down. The test asserts that GHC points at
+-- the tagged line.
+module BusError where
+
+import           Circuit
+import           Clash.Prelude
+
+boolC :: Circuit (Signal dom Bool) (Signal dom Bool)
+boolC = idC
+
+busError :: Circuit (Signal dom Int) (Signal dom Int)
+busError = circuit $ \a -> do
+  b <- idC -< a
+  c <- boolC -< b      -- bus-error-marker
+  d <- idC -< c
+  e <- idC -< d
+  idC -< e


### PR DESCRIPTION
Since #14 the error locations often pointed to the end of the circuit instead of the correct location. That should now be fixed, along with a regression test.

Hopefully resolves #35.